### PR TITLE
Image renaming prompt on paste

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -5,4 +5,5 @@
  * @author Andreas Gohr <gohr@cosmocode.de>
  */
 
-$conf['filename']    = '@NS@:pasted:%Y%m%d-%H%M%S';
+$conf['filename'] = '@NS@:pasted:%Y%m%d-%H%M%S';
+$conf['show_rename_prompt'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -7,4 +7,4 @@
 
 
 $meta['filename'] = array('string');
-
+$meta['show_rename_prompt'] = array('onoff');

--- a/script.js
+++ b/script.js
@@ -42,11 +42,16 @@
             const item = items[index];
 
             if (item.kind === 'file') {
+
+                // attemp to get original file name
+                const file = item.getAsFile();
+                const originalName = file.name ? file.name.replace(/\.[^/.]+$/, "") : "";
+
                 const reader = new FileReader();
                 reader.onload = event => {
-                    uploadData(event.target.result);
+                    uploadData(event.target.result, originalName);
                 };
-                reader.readAsDataURL(item.getAsFile());
+                reader.readAsDataURL(file);
 
                 // we had at least one file, prevent default
                 e.preventDefault();
@@ -179,15 +184,17 @@
      * Uploads the given dataURL to the server and displays a progress dialog, inserting the syntax on success
      *
      * @param {string} dataURL
+     * @param {string} suggestedName Optional name from the original file
      */
-    async function uploadData(dataURL) {
+    async function uploadData(dataURL, suggestedName = "") {
         let name = "";
         
         // Determine if renaming prompt should be shown
         const showPrompt = (typeof plugin_imgpaste_show_prompt !== 'undefined') && (String(plugin_imgpaste_show_prompt) === '1');
         
         if (showPrompt) {
-            name = window.prompt("Enter image name (leave empty for default):", "");
+            // Use suggestedName (if any) as the default value in the prompt
+            name = window.prompt("Enter image name (leave empty for default):", suggestedName);
             if (name === null) return; // Abort upload if user cancels
         }
 


### PR DESCRIPTION
Adds an optional feature to allow users to rename images during the paste process. It provides opportunities to rename images immediately without needing to go to the media manager later.

<img width="1902" height="908" alt="example" src="https://github.com/user-attachments/assets/6b65c92b-0b19-405e-8413-b1f5075fa28a" />

## Features

1. Image renaming prompt: when enabled, a dialog appears asking for a custom filename.
  - If a name is entered, the image is saved with the new name.
  - If left empty, it falls back to the default filename logic defined in the plugin settings.
2. Configuration setting: a new config option `show_rename_prompt` has been added.
  - Default is disabled to maintain the original behavior